### PR TITLE
Add null character check to validation.

### DIFF
--- a/lib/utf8-cleaner/uri_string.rb
+++ b/lib/utf8-cleaner/uri_string.rb
@@ -6,6 +6,7 @@ module UTF8Cleaner
     HEX_CHARS = '0-9a-fA-F'
     HEX_CHARS_REGEX = /[#{HEX_CHARS}]/
     INVALID_PERCENT_ENCODING_REGEX = /%(?![#{HEX_CHARS}]{2})/
+    NULL_CHARS = /(%00)/
 
     def initialize(data)
       self.data = data
@@ -87,8 +88,7 @@ module UTF8Cleaner
     end
 
     def valid_uri_encoded_utf8(string)
-      URI.decode(string).force_encoding('UTF-8').valid_encoding? &&
-        string !~ INVALID_PERCENT_ENCODING_REGEX
+      URI.decode(string).force_encoding('UTF-8').valid_encoding? && string !~ INVALID_PERCENT_ENCODING_REGEX && string !~ NULL_CHARS
     rescue ArgumentError => e
       if e.message =~ /invalid byte sequence/
         return false

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -10,9 +10,9 @@ module UTF8Cleaner
     describe "with a big nasty env" do
       let :env do
         {
-          'PATH_INFO' => 'foo/%FFbar%2e%2fbaz%26%3B',
+          'PATH_INFO' => 'foo/%FFbar%2e%2fbaz%26%3B%00',
           'QUERY_STRING' => 'foo=bar%FF',
-          'HTTP_REFERER' => 'http://example.com/blog+Result:+%ED%E5+%ED%E0%F8%EB%EE%F1%FC+%F4%EE%F0%EC%FB+%E4%EB%FF+%EE%F2%EF%F0%E0%E2%EA%E8',
+          'HTTP_REFERER' => 'http://example.com/blog+Result:+%ED%E5+%ED%E0%F8%EB%EE%F1%FC+%F4%EE%F0%EC%FB+%E4%EB%FF+%EE%F2%EF%F0%E0%E2%EA%E8%00',
           'HTTP_USER_AGENT' => "Android Versi\xF3n/4.0\x93",
           'REQUEST_URI' => '%C3%89%E2%9C%93',
           'rack.input' => StringIO.new("foo=%FFbar%F8"),

--- a/spec/uri_string_spec.rb
+++ b/spec/uri_string_spec.rb
@@ -13,6 +13,7 @@ module UTF8Cleaner
     let(:no_byte_at_all)      { URIString.new('%') }
     let(:not_even_hex_chars1) { URIString.new('%x') }
     let(:not_even_hex_chars2) { URIString.new('%0zhey') }
+    let(:null_byte_chars)     { URIString.new("%00hey%00") }
     let(:mixed_encodings)     { URIString.new('§%e2') }
 
     describe '#new' do
@@ -28,6 +29,7 @@ module UTF8Cleaner
       it { expect(no_byte_at_all.cleaned).to eq('') }
       it { expect(not_even_hex_chars1.cleaned).to eq('') }
       it { expect(not_even_hex_chars2.cleaned).to eq('hey') }
+      it { expect(null_byte_chars.cleaned).to eq('hey') }
       it { expect(mixed_encodings.cleaned).to eq('§') }
     end
 
@@ -41,6 +43,7 @@ module UTF8Cleaner
       it { expect(no_byte_at_all).to_not be_valid }
       it { expect(not_even_hex_chars1).to_not be_valid }
       it { expect(not_even_hex_chars2).to_not be_valid }
+      it { expect(null_byte_chars).to_not be_valid }
       it { expect(mixed_encodings).to_not be_valid }
     end
 


### PR DESCRIPTION
Currently utf8-cleaner treats `%00` null characters as valid which breaks our router.